### PR TITLE
Removed subsection 5.2; not needed

### DIFF
--- a/LineTAP.tex
+++ b/LineTAP.tex
@@ -516,11 +516,6 @@ FROM casa_lines.line_tap
 GROUP BY inchi
 \end{lstlisting}
 
-
-\subsection{Translating VAMDC Queries}
-TBD
-
-
 \section{Mapping from VAMDCXSAMS}
 \label{sect:mapping}
 


### PR DESCRIPTION
Subsection "Translating VAMDC queries" without content removed; not really necessary.